### PR TITLE
Provide a valid subject when pushing event data.

### DIFF
--- a/coscale.py
+++ b/coscale.py
@@ -82,7 +82,7 @@ def _eventdatapush(message, timestamp, token, url):
     data = {
         'message': 		message,
         'timestamp': 	timestamp,
-        'subject':		'subject'}
+        'subject':		'a'}
     headers = {'HTTPAuthorization': token}
     req = requests.post(url, data=data, headers=headers, timeout=1)
     if req.status_code != 200:


### PR DESCRIPTION
"subject" should either be the short of the server or group, or be "a" for application wide.
