### PR TITLE
Fixed documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Salt plugin
 
-## [Go to documentation](http://docs.coscale.com/installation/events/automation/salt/)
+## [Go to documentation](http://docs.coscale.com/events/automation/salt/)


### PR DESCRIPTION
Changed to new documentation url
http://docs.coscale.com/events/automation/salt/
